### PR TITLE
Add ARP and ARC commands

### DIFF
--- a/src/playback/playback.h
+++ b/src/playback/playback.h
@@ -73,6 +73,26 @@ struct PlaybackTrackQueue {
   int phraseRow;
 };
 
+enum PlaybackArpType {
+  arpTypeUp,
+  arpTypeDown,
+  arpTypeUpDown,
+  arpTypeUp1Oct,
+  arpTypeDown1Oct,
+  arpTypeUpDown1Oct,
+  arpTypeUp2Oct,
+  arpTypeDown2Oct,
+  arpTypeUpDown2Oct,
+  arpTypeUp3Oct,
+  arpTypeDown3Oct,
+  arpTypeUpDown3Oct,
+  arpTypeUp4Oct,
+  arpTypeDown4Oct,
+  arpTypeUpDown4Oct,
+  arpTypeUp5Oct,
+  arpTypeMax,
+};
+
 struct PlaybackTrackState {
   struct PlaybackTrackQueue queue;
 
@@ -87,6 +107,9 @@ struct PlaybackTrackState {
   int grooveRow;
 
   int frameCounter;
+
+  int arpSpeed;
+  enum PlaybackArpType arpType;
 
   // Currently playing note
   struct PlaybackNoteState note;

--- a/src/playback/playback_fx.h
+++ b/src/playback/playback_fx.h
@@ -16,17 +16,10 @@ struct PlaybackFXData_PSL {
   uint8_t counter;
 };
 
-struct PlaybackFXData_ARP {
-  uint8_t counter;
-  uint8_t speed;
-  uint8_t type;
-};
-
 union PlaybackFXData {
   struct PlaybackFXData_PBN pbn;
   struct PlaybackFXData_CountFX count_fx;
   struct PlaybackFXData_PSL psl;
-  struct PlaybackFXData_ARP arp;
 };
 
 struct PlaybackFXState {

--- a/src/screens/help.c
+++ b/src/screens/help.c
@@ -10,13 +10,22 @@ char* helpFXHint(uint8_t* fx, int isTable) {
   buffer[0] = 0; // Terminate string for unsupported FX
   int note;
 
+  const char* arpModeHelp[16]={
+    "Up (+0 oct)", "Down (+0 oct)", "Up/Down (+0 oct)",
+    "Up (+1 oct)", "Down (+1 oct)", "Up/Down (+1 oct)",
+    "Up (+2 oct)", "Down (+2 oct)", "Up/Down (+2 oct)",
+    "Up (+3 oct)", "Down (+3 oct)", "Up/Down (+3 oct)",
+    "Up (+4 oct)", "Down (+4 oct)", "Up/Down (+4 oct)",
+    "Up (+5 oct)"
+  };
+
   switch ((enum FX)fx[0]) {
     case fxARP: // Arpeggio
       sprintf(buffer, "Arpeggio 0, %hhu, %hhu semitones", (fx[1] & 0xf0) >> 4, (fx[1] & 0xf));
       break;
     case fxARC: // Arpeggio config
-    sprintf(buffer, "Arpeggio config");
-    break;
+      sprintf(buffer, "ARP config: %s, %d tics",arpModeHelp[(fx[1] & 0xf0) >> 4],(fx[1] & 0xf));
+      break;
     case fxPVB: // Pitch vibrato
       sprintf(buffer, "Pitch vibrato, speed %hhu, depth %hhu", (fx[1] & 0xf0) >> 4, (fx[1] & 0xf));
       break;


### PR DESCRIPTION
Rough implementation of ARP and ARC. I moved the ARP settings to track level so that ARC settings would persist. Not sure if there would be a better way to do this?

There is still a little issue with ARC, the root note is played on the first ARP tic when ARC is changed to down from one of the up modes (happens only on the first tic after the mode change). 
