### PR TITLE
Add Anbernic RG35XX+ support

### DIFF
--- a/platforms/sdl2/corelib_audio.c
+++ b/platforms/sdl2/corelib_audio.c
@@ -23,8 +23,6 @@ int audioSetup(AudioCallback* audioCallback, int sampleRate, int bufferSize) {
     return 1;
   }
 
-  SDL_PauseAudio(0);
-
   return 0;
 }
 

--- a/platforms/sdl2/corelib_gfx.c
+++ b/platforms/sdl2/corelib_gfx.c
@@ -29,20 +29,29 @@ static int isDirty;
 
 static char charBuffer[80];
 
+// FIXME: On RG35XX+, the SDL2 seems to be built without haptic
+// support enabled, so SDL_INIT_EVERYTHING will fail.
+#ifdef RG35XX_PLUS_BUILD
+#define SDL_INIT_FLAGS (SDL_INIT_EVERYTHING & ~SDL_INIT_HAPTIC)
+#else
+#define SDL_INIT_FLAGS (SDL_INIT_EVERYTHING)
+#endif
+
 int gfxSetup(void) {
-  if (SDL_Init(SDL_INIT_EVERYTHING) != 0) {
-    printf("SDL2 Initialization Error: %s\n", SDL_GetError());
+  if (SDL_Init(SDL_INIT_FLAGS) != 0) {
+    fprintf(stderr, "SDL2 Initialization Error: %s\n", SDL_GetError());
     return 1;
   }
 
   sprintf(charBuffer, "%s v%s (%s)", appTitle, appVersion, appBuild);
+
   window = SDL_CreateWindow(charBuffer,
     SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
     WINDOW_WIDTH, WINDOW_HEIGHT,
     SDL_WINDOW_SHOWN);
 
   if (!window) {
-    printf("SDL2 Create Window Error: %s\n", SDL_GetError());
+    fprintf(stderr, "SDL2 Create Window Error: %s\n", SDL_GetError());
     SDL_Quit();
     return 1;
   }

--- a/platforms/sdl2/corelib_mainloop.c
+++ b/platforms/sdl2/corelib_mainloop.c
@@ -6,7 +6,7 @@
 #define FPS 60
 
 // Keyboard mapping for desktop and RG35xx
-#ifdef DESKTOP_BUILD
+#if defined(DESKTOP_BUILD)
 // Desktop mapping
 #define BTN_UP          (SDLK_UP)
 #define BTN_DOWN        (SDLK_DOWN)
@@ -27,6 +27,27 @@
 #define BTN_VOLUME_DOWN (SDLK_MINUS)
 #define BTN_POWER       0
 #define BTN_EXIT        0
+#elif defined(RG35XX_PLUS_BUILD)
+// RG35xx+ mapping
+#define BTN_UP          (0x0100 + SDL_HAT_UP)
+#define BTN_DOWN        (0x0100 + SDL_HAT_DOWN)
+#define BTN_LEFT        (0x0100 + SDL_HAT_LEFT)
+#define BTN_RIGHT       (0x0100 + SDL_HAT_RIGHT)
+#define BTN_A           0
+#define BTN_B           1
+#define BTN_X           3
+#define BTN_Y           2
+#define BTN_L1          4
+#define BTN_R1          5
+#define BTN_L2          9
+#define BTN_R2          10
+#define BTN_SELECT      6
+#define BTN_START       7
+#define BTN_MENU        8
+#define BTN_VOLUME_UP   14
+#define BTN_VOLUME_DOWN 13
+#define BTN_POWER       1073741926
+#define BTN_EXIT        (BTN_POWER)
 #else
 // RG35xx mapping
 #define BTN_UP          119
@@ -65,6 +86,36 @@ static int decodeKey(int sym) {
   return 0;
 }
 
+#if defined(RG35XX_PLUS_BUILD)
+void translateJoystickEvent(SDL_Event *event) {
+  static uint8_t lastHatState = SDL_HAT_CENTERED;
+
+  switch(event->type) {
+    case SDL_JOYHATMOTION:
+      if(event->jhat.hat == 0) {
+        if (event->jhat.value == SDL_HAT_CENTERED) {
+          event->type = SDL_KEYUP;
+        } else {
+          event->type = SDL_KEYDOWN;
+          lastHatState = event->jhat.value;
+        }
+        event->key.keysym.sym = 0x0100 + lastHatState;
+      }
+      break;
+
+    case SDL_JOYBUTTONUP:
+      event->type = SDL_KEYUP;
+      event->key.keysym.sym = event->jbutton.button;
+      break;
+
+    case SDL_JOYBUTTONDOWN:
+      event->type = SDL_KEYDOWN;
+      event->key.keysym.sym = event->jbutton.button;
+      break;
+  }
+}
+#endif
+
 void mainLoopRun(void (*draw)(void), void (*onEvent)(enum MainLoopEvent event, int value, void* userdata)) {
   uint32_t delay = 1000 / FPS;
   uint32_t start;
@@ -72,10 +123,17 @@ void mainLoopRun(void (*draw)(void), void (*onEvent)(enum MainLoopEvent event, i
   SDL_Event event;
   int menu = 0;
 
+#if defined(RG35XX_PLUS_BUILD)
+  (void)!SDL_JoystickOpen(0);
+#endif
+
   while (1) {
     start = SDL_GetTicks();
 
     while (SDL_PollEvent(&event)) {
+#if defined(RG35XX_PLUS_BUILD)
+      translateJoystickEvent(&event);
+#endif
       if (event.type == SDL_QUIT || (event.type == SDL_KEYDOWN && (
           (event.key.keysym.sym == BTN_POWER) ||
           (event.key.keysym.sym == BTN_EXIT) ||

--- a/src/app.c
+++ b/src/app.c
@@ -128,6 +128,8 @@ void appSetup(void) {
   audioManager.start(appSettings.audioSampleRate, appSettings.audioBufferSize, project.frameRate);
   audioManager.initChips();
   audioManager.setFrameCallback(frameCallback, NULL);
+  audioManager.resume();
+
   screenSetup(&screenSong, 0);
 }
 

--- a/src/psg_play.c
+++ b/src/psg_play.c
@@ -22,7 +22,7 @@ int psgReadFile(char* path) {
   fseek(psgFile, 0, SEEK_SET);
 
   psgData = malloc(psgSize);
-  fread(psgData, psgSize, 1, psgFile);
+  (void)!fread(psgData, psgSize, 1, psgFile);
   fclose(psgFile);
 
   psgOffset = 16;


### PR DESCRIPTION
This PR adds support for Anbernic RG35XX Plus.
The changes required are surprisingly minimal:

* Added joystick as input source (original device uses `j2k.so` to translate joystick events to keyboard events, we don't do that here)
* Fixed SDL2 initialization issue with missing haptics support
* Fixed segfault when SDL2 fires an audio callback before AY chips are initialized

Building requires defining `-DRG35XX_PLUS_BUILD` and using the SDL2 platform. Unfortunately I haven't found a suitable  toolchain yet to cross-compile and am building directly on the device, so I'm not making any changes to the Makefile for now.