### PR TITLE
Feature: vt2 instruments import

### DIFF
--- a/platforms/shared/corelib_file.c
+++ b/platforms/shared/corelib_file.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <dirent.h>
@@ -106,10 +107,22 @@ struct FileEntry* fileListDirectory(const char* path, const char* extension, int
     
     int isDir = S_ISDIR(statBuf.st_mode);
     
-    // If it's a file, check extension
-    if (!isDir && extension) {
+    if (!isDir && extension && extension[0] != '\0') {
       char* dot = strrchr(entry->d_name, '.');
-      if (!dot || strcmp(dot, extension) != 0) continue;
+      if (!dot) continue;
+      
+      int match = 0;
+      const char* pos = extension;
+      while (pos) {
+        if (strcasecmp(pos, dot) == 0 || 
+            (strncasecmp(pos, dot, strlen(dot)) == 0 && pos[strlen(dot)] == ',')) {
+          match = 1;
+          break;
+        }
+        pos = strchr(pos, ',');
+        if (pos) pos++;
+      }
+      if (!match) continue;
     }
     
     // Resize array if needed

--- a/src/chipnomad_lib/import_vts.c
+++ b/src/chipnomad_lib/import_vts.c
@@ -1,0 +1,232 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <project.h>
+#include <corelib_file.h>
+
+#define VTS_COL_TONE        0
+#define VTS_COL_NOISE       1
+#define VTS_COL_ENVELOPE    2
+#define VTS_COL_PITCH       4
+#define VTS_COL_VOLUME      15
+#define VTS_COL_NOISE_FREQ  16
+#define VTS_COL_LOOP_START  16
+#define VTS_COL_LOOP_END    25
+
+#define VTS_PITCH_THRESHOLD 256
+#define VTS_PITCH_SCALE     2
+#define CHIPNOMAD_PIT_MAX   127
+#define CHIPNOMAD_PIT_MIN   -128
+#define TABLE_ROW_COUNT     16
+
+#define FX_SLOT_CONTROL  0
+#define FX_SLOT_NOISE    1  //noise and env offsets.. todo: FIX :D 
+#define FX_SLOT_MIXER    2
+#define FX_SLOT_PITCH    3
+
+#define AYM_TONE_BIT     0x01
+#define AYM_NOISE_BIT    0x02
+#define AYM_ENVELOPE_BIT 0xC0
+
+static int parseVTSHex(char c) {
+  if (c == '_') return 0;
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  return 0;
+}
+
+static int parseVTSOffset(const char* str) {
+  int sign = 1;
+  int value = 0;
+  
+  if (str[0] == '-') sign = -1;
+  
+  for (int i = 1; i <= 3; i++) {
+    if (str[i] == '_') break;
+    if (str[i] >= '0' && str[i] <= '9') {
+      value = value * 10 + (str[i] - '0');
+    }
+  }
+  
+  return sign * value;
+}
+
+static void initTableRow(struct TableRow* row) {
+  row->pitchFlag = 0;
+  row->pitchOffset = 0;
+  row->volume = EMPTY_VALUE_8;
+  for (int i = 0; i < 4; i++) {
+    row->fx[i][0] = EMPTY_VALUE_8;
+    row->fx[i][1] = 0;
+  }
+}
+
+static inline int isValidDataChar(char c) {
+  return c != '_' && c != ' ' && c != '-';
+}
+
+static inline int clampToInt8(int value) {
+  if (value > CHIPNOMAD_PIT_MAX) return CHIPNOMAD_PIT_MAX;
+  if (value < CHIPNOMAD_PIT_MIN) return CHIPNOMAD_PIT_MIN;
+  return value;
+}
+
+static void setPitEffect(struct TableRow* row, int pitValue) {
+  row->fx[FX_SLOT_PITCH][0] = fxPIT;
+  row->fx[FX_SLOT_PITCH][1] = (uint8_t)pitValue;
+}
+
+static void parseVTSLine(const char* line, struct TableRow* row) {
+  initTableRow(row);
+  
+  size_t len = strlen(line);
+  if (len < VTS_COL_VOLUME + 1) return;
+  
+  int hasTone = (line[VTS_COL_TONE] == 'T' || line[VTS_COL_TONE] == 't');
+  int hasNoise = (line[VTS_COL_NOISE] == 'N' || line[VTS_COL_NOISE] == 'n');
+  int hasEnv = (line[VTS_COL_ENVELOPE] == 'E' || line[VTS_COL_ENVELOPE] == 'e');
+  
+  if (isValidDataChar(line[VTS_COL_VOLUME])) {
+    row->volume = parseVTSHex(line[VTS_COL_VOLUME]);
+  }
+  
+  if (hasNoise && len > VTS_COL_NOISE_FREQ) {
+    char noiseChar = line[VTS_COL_NOISE_FREQ];
+    if (isValidDataChar(noiseChar) && noiseChar != 'L' && noiseChar != 'l') {
+      row->fx[FX_SLOT_NOISE][0] = fxNOI;
+      row->fx[FX_SLOT_NOISE][1] = parseVTSHex(noiseChar);
+    }
+  }
+  
+  int mixerMode = (hasTone ? AYM_TONE_BIT : 0) | 
+                  (hasNoise ? AYM_NOISE_BIT : 0) | 
+                  (hasEnv ? AYM_ENVELOPE_BIT : 0);
+
+  row->fx[FX_SLOT_MIXER][0] = fxAYM;
+  row->fx[FX_SLOT_MIXER][1] = mixerMode;
+}
+
+static void initAYInstrument(struct Instrument* inst) {
+  inst->type = instAY;
+  inst->tableSpeed = 1;
+  inst->transposeEnabled = 1;
+  
+  inst->chip.ay.veA = 0;
+  inst->chip.ay.veD = 0;
+  inst->chip.ay.veS = 15;
+  inst->chip.ay.veR = 0;
+  inst->chip.ay.autoEnvN = 0;
+  inst->chip.ay.autoEnvD = 0;
+}
+
+static void extractInstrumentName(const char* line, const char* path, char* outName, size_t maxLen) {
+  if (line[0] == '[') {
+    size_t len = strlen(line);
+    size_t nameLen = 0;
+    for (size_t i = 1; i < len && line[i] != ']' && nameLen < maxLen - 1; i++) {
+      outName[nameLen++] = line[i];
+    }
+    outName[nameLen] = '\0';
+  } else {
+    const char* filename = strrchr(path, '/');
+    filename = filename ? filename + 1 : path;
+    
+    strncpy(outName, filename, maxLen - 1);
+    outName[maxLen - 1] = '\0';
+    
+    char* ext = strstr(outName, ".vts");
+    if (ext) *ext = '\0';
+  }
+}
+
+static int findLoopMarker(const char* line) {
+  size_t len = strlen(line);
+  for (size_t i = VTS_COL_LOOP_START; i < len && i < VTS_COL_LOOP_END; i++) {
+    if (line[i] == 'L' || line[i] == 'l') {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int instrumentLoadVTS(const char* path, int instrumentIdx) {
+  if (instrumentIdx < 0 || instrumentIdx >= PROJECT_MAX_INSTRUMENTS) {
+    return 1;
+  }
+  
+  int fileId = fileOpen(path, 0);
+  if (fileId == -1) {
+    return 1;
+  }
+  
+  struct Instrument* inst = &project.instruments[instrumentIdx];
+  struct Table* table = &project.tables[instrumentIdx];
+  
+  initAYInstrument(inst);
+  
+  char* lpstr = fileReadString(fileId);
+  if (lpstr == NULL) {
+    fileClose(fileId);
+    return 1;
+  }
+  
+  extractInstrumentName(lpstr, path, inst->name, PROJECT_INSTRUMENT_NAME_LENGTH);
+  
+  int rowCount = 0;
+  int loopRow = -1;
+  int vtsOffsets[TABLE_ROW_COUNT] = {0};
+  
+  while (rowCount < TABLE_ROW_COUNT) {
+    lpstr = fileReadString(fileId);
+    if (lpstr == NULL || lpstr[0] == '[') break;
+    
+    size_t lineLen = strlen(lpstr);
+    if (lineLen < 3) continue;
+    
+    if (findLoopMarker(lpstr)) {
+      loopRow = rowCount;
+    }
+    
+    if (lineLen >= VTS_COL_PITCH + 5 && 
+        (lpstr[VTS_COL_PITCH] == '+' || lpstr[VTS_COL_PITCH] == '-')) {
+      vtsOffsets[rowCount] = parseVTSOffset(&lpstr[VTS_COL_PITCH]);
+    }
+    
+    parseVTSLine(lpstr, &table->rows[rowCount]);
+    rowCount++;
+  }
+  
+  for (int i = 1; i < rowCount; i++) {
+    int delta = vtsOffsets[i] - vtsOffsets[i-1];
+    
+    if (delta == 0) continue;
+    
+    if (abs(delta) < VTS_PITCH_THRESHOLD) {
+      int pitValue = delta / VTS_PITCH_SCALE;
+      pitValue = clampToInt8(pitValue);
+      
+      if (pitValue == 0) {
+        pitValue = (delta > 0) ? 1 : -1;
+      }
+      
+      setPitEffect(&table->rows[i], pitValue);
+    }
+  }
+  
+  if (loopRow >= 0 && rowCount < TABLE_ROW_COUNT) {
+    initTableRow(&table->rows[rowCount]);
+    table->rows[rowCount].fx[FX_SLOT_CONTROL][0] = fxTHO;
+    table->rows[rowCount].fx[FX_SLOT_CONTROL][1] = loopRow;
+    rowCount++;
+  }
+  
+  for (int i = rowCount; i < TABLE_ROW_COUNT; i++) {
+    initTableRow(&table->rows[i]);
+  }
+  
+  fileClose(fileId);
+  return 0;
+}
+

--- a/src/chipnomad_lib/import_vts.h
+++ b/src/chipnomad_lib/import_vts.h
@@ -1,0 +1,7 @@
+#ifndef IMPORT_VTS_H
+#define IMPORT_VTS_H
+
+int instrumentLoadVTS(const char* path, int instrumentIdx);
+
+#endif
+

--- a/src/screens/file_browser.c
+++ b/src/screens/file_browser.c
@@ -11,7 +11,7 @@ static int entryCount = 0;
 static int selectedIndex = 0;
 static int topIndex = 0;
 static char currentPath[2048];
-static char fileExtension[8];
+static char fileExtension[32];
 static char browserTitle[32];
 static char saveFilename[256];
 static char saveExtension[8];
@@ -77,8 +77,8 @@ void fileBrowserRefresh(void) {
 void fileBrowserSetup(const char* title, const char* extension, const char* startPath, void (*fileCallback)(const char*), void (*cancelCallback)(void)) {
   strncpy(browserTitle, title, 31);
   browserTitle[31] = 0;
-  strncpy(fileExtension, extension, 7);
-  fileExtension[7] = 0;
+  strncpy(fileExtension, extension, 31);
+  fileExtension[31] = 0;
   isFolderMode = 0;
   onFileSelected = fileCallback;
   onCancelled = cancelCallback;


### PR DESCRIPTION
Adds support for importing .vti instruments.

Currently utilizes semitone offsets, PIT, AYM, NOA, VOL and THO commands to more or less resemble what you would hear in VT2 when using the instrument. 

The biggest problem right now with this is how PIT affects looped section. VT2 pitch column is absolute, while chipnomad uses absolute semitone offsets and PIT commands which are relative.