### PR TITLE
Fix install_name_tool argument (macos)

### DIFF
--- a/tracker/Makefile.macos
+++ b/tracker/Makefile.macos
@@ -32,7 +32,7 @@ macOS-app-bundle: macOS
 	@cp -r packaging/common/* $(BUILD)/
 	@iconutil -c icns packaging/macos/ChipNomad.iconset -o $(BUILD)/$(APP_BUNDLE)/Contents/Resources/ChipNomad.icns 2>/dev/null || echo "Warning: Icon generation failed"
 	@cp /opt/homebrew/lib/libSDL2-2.0.0.dylib $(BUILD)/$(APP_BUNDLE)/Contents/Frameworks/ || echo "Warning: SDL2 library not found"
-	@install_name_tool -change /opt/homebrew/lib/libSDL2-2.0.0.dylib @executable_path/../Frameworks/libSDL2-2.0.0.dylib $(BUILD)/$(APP_BUNDLE)/Contents/MacOS/chipnomad 2>/dev/null || true
+	@install_name_tool -change /opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib @executable_path/../Frameworks/libSDL2-2.0.0.dylib $(BUILD)/$(APP_BUNDLE)/Contents/MacOS/chipnomad 2>/dev/null || true
 	@cp packaging/macos/Info.plist $(BUILD)/$(APP_BUNDLE)/Contents/
 	@sed -i '' "s/VERSION_PLACEHOLDER/$$(grep 'appVersion.*=' src/version.c | cut -d'"' -f2)/g" $(BUILD)/$(APP_BUNDLE)/Contents/Info.plist
 	@echo ".app bundle created at $(BUILD)/$(APP_BUNDLE)"


### PR DESCRIPTION
The old path does not match the path linked in the executable, so the command doesn't work.
This means the app depends on Homebrew SDL2 and does not use the bundled library. If SDL2 is not installed via Homebrew you get the following error:
```shell
❯ ChipNomad.app/Contents/MacOS/chipnomad
dyld[70331]: Library not loaded: /opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib
  Referenced from: <D62710E5-38A2-394B-B5F9-7FC1C47FC916> /Users/danielnagel/Downloads/ChipNomad-2026-02-01-0.1.0b-macOS/ChipNomad.app/Contents/MacOS/chipnomad
  Reason: tried: '/opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib' (no such file), '/opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib' (no such file)
```

Old command:
```
@install_name_tool -change /opt/homebrew/lib/libSDL2-2.0.0.dylib @executable_path/../Frameworks/libSDL2-2.0.0.dylib $(BUILD)/$(APP_BUNDLE)/Contents/MacOS/chipnomad 2>/dev/null || true
```

Output from otool:
```
Load command 14
          cmd LC_LOAD_DYLIB
      cmdsize 72
         name /opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 3201.10.0
compatibility version 3201.0.0
```

New command matching the path linked in the executable:
```
@install_name_tool -change /opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib @executable_path/../Frameworks/libSDL2-2.0.0.dylib $(BUILD)/$(APP_BUNDLE)/Contents/MacOS/chipnomad 2>/dev/null || true
```

Output from otool after the change:
```
Load command 14
          cmd LC_LOAD_DYLIB
      cmdsize 80
         name @executable_path/../Frameworks/libSDL2-2.0.0.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 3201.10.0
compatibility version 3201.0.0
```